### PR TITLE
Trains search UI improvement

### DIFF
--- a/website/src/_includes/trains.njk
+++ b/website/src/_includes/trains.njk
@@ -12,19 +12,19 @@
             <input class="uk-search-input" type="search" placeholder="{{ "global.search_box" | i18n }}" style="background:#fff"
                 id="train_search_input">
             <div uk-dropdown="pos: bottom-center" id="search_options_dropdown">
-                <ul class="uk-nav uk-dropdown-nav uk-width-large">
-                    <table class="uk-table uk-table-small uk-table-hover">
+                <div class="uk-width-xlarge" style="overflow-y: scroll; max-height: 400px;">
+                    <table class="uk-table uk-table-small uk-table-hover uk-text-left">
                         <thead>
                             <tr>
-                                <th>{{ "global.train_number" | i18n }}"</th>
-                                <th>{{ "global.departure" | i18n }}"</th>
-                                <th>{{ "global.destination" | i18n }}"</th>
+                                <th>{{ "global.train_number" | i18n }}</th>
+                                <th>{{ "global.departure" | i18n }}</th>
+                                <th>{{ "global.destination" | i18n }}</th>
                             </tr>
                         </thead>
                         <tbody id="search_options_dropdown_content">
                         </tbody>
                     </table>
-                </ul>
+                </div>
             </div>
         </form>
     </div>

--- a/website/src/static/js/trains_search.js
+++ b/website/src/static/js/trains_search.js
@@ -80,7 +80,7 @@ let dropdown_content = document.getElementById('search_options_dropdown_content'
 function populate_dropdown_from_dataset(dataset) {
     let dropdown_content = document.getElementById('search_options_dropdown_content');
     let dropdown_content_html = '';
-    let MAX_RESULTS = 10;
+    let MAX_RESULTS = 100;
     let table_length = dataset.length > MAX_RESULTS ? MAX_RESULTS : dataset.length;
     for (let i = 0; i < table_length; i++) {
         let train = dataset[i];

--- a/website/src/static/libraries/ui/style.css
+++ b/website/src/static/libraries/ui/style.css
@@ -109,6 +109,13 @@ p{
     z-index: 10000;
 }
 
+.uk-dropdown .uk-table-hover tr:hover {
+    color: #223046;
+}
+
+.uk-table-hover td {
+    cursor: pointer;
+}
 
 
 .ot-ranking-table .ot-train-logo-ic {


### PR DESCRIPTION
This PR fixes #23 and improves the UI to search a specific train: 

1. **It's now easier to read trains from the list**
before, when hovering with the mouse on a table row, the background was getting white and the text color was not changing, so the row was practically unreadable 
<img width="627" alt="image" src="https://github.com/giacomoorsi/OpenRitardi/assets/11297544/12ef187a-a25d-4f10-b280-788a27bca1bd">

 
 
---
2. **We now show more alternatives**
Before, we were only showing 10 alternatives, while now we show 100 in the table, with a slider
<img width="604" alt="image" src="https://github.com/giacomoorsi/OpenRitardi/assets/11297544/3bb2dc35-b54f-4f0d-ba85-ed024a41abb6">
